### PR TITLE
Update to .NET 8.0 and add new repository interfaces

### DIFF
--- a/src/FontesCSharp.Infra/FontesCSharp.Infra.csproj
+++ b/src/FontesCSharp.Infra/FontesCSharp.Infra.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Repositories\Interfaces\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
   </ItemGroup>
 

--- a/src/FontesCSharp.Infra/Repositories/Interfaces/IRepository.cs
+++ b/src/FontesCSharp.Infra/Repositories/Interfaces/IRepository.cs
@@ -1,0 +1,6 @@
+﻿namespace FontesCSharp.Infra.Repositories.Interfaces
+{
+    public interface IRepository
+    {
+    }
+}

--- a/src/FontesCSharp.Infra/Repositories/Interfaces/IUnityOfWork.cs
+++ b/src/FontesCSharp.Infra/Repositories/Interfaces/IUnityOfWork.cs
@@ -1,0 +1,6 @@
+﻿namespace FontesCSharp.Infra.Repositories.Interfaces
+{
+    public interface IUnityOfWork
+    {
+    }
+}


### PR DESCRIPTION
Updated FontesCSharp.Infra.csproj to target .NET 8.0. Removed <Folder Include="Repositories\Interfaces\" /> entry. Added IRepository and IUnityOfWork interfaces in the FontesCSharp.Infra.Repositories.Interfaces namespace.